### PR TITLE
Add a 'github_banner_image' option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,10 @@ To use:
    * `github_banner`: `true` or `false` (default: `false`) - whether to apply a
    'Fork me on Github' banner in the top right corner of the page.
        * If `true`, requires that you set `github_user` and `github_repo`.
+   * `github_banner_image`: Path to an image (as with `logo`, relative to 
+   `$PROJECT/_static/`) to be used as a custom 'Fork me on Github' banner. 
+       * If unset (the default), a standard 'Fork me on Github' banner will be 
+       used.
    * `travis_button`: `true`, `false` or a Github-style `"account/repo"`
    string - used to display a Travis-CI build status button in the sidebar. If
    `true`, uses your `github_(user|repo)` settings; defaults to `false.`

--- a/alabaster/layout.html
+++ b/alabaster/layout.html
@@ -24,7 +24,7 @@
 
     {% if theme_github_banner|lower == 'true' %}
     <a href="https://github.com/{{ theme_github_user }}/{{ theme_github_repo }}" class="github">
-        <img style="position: absolute; top: 0; right: 0; border: 0;" src="http://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png" alt="Fork me on GitHub"  class="github"/>
+        <img style="position: absolute; top: 0; right: 0; border: 0;" src="{% if theme_github_banner_image %}{{ pathto('_static/' ~ theme_github_banner_image, 1) }}{% else %}http://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png{% endif %}" alt="Fork me on GitHub"  class="github"/>
     </a>
     {% endif %}
 

--- a/alabaster/layout.html
+++ b/alabaster/layout.html
@@ -24,7 +24,7 @@
 
     {% if theme_github_banner|lower == 'true' %}
     <a href="https://github.com/{{ theme_github_user }}/{{ theme_github_repo }}" class="github">
-        <img style="position: absolute; top: 0; right: 0; border: 0;" src="{% if theme_github_banner_image %}{{ pathto('_static/' ~ theme_github_banner_image, 1) }}{% else %}http://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png{% endif %}" alt="Fork me on GitHub"  class="github"/>
+        <img style="position: absolute; top: 0; right: 0; border: 0;" src="{{ pathto('_static/' ~ theme_github_banner_image, 1) if theme_github_banner_image else 'http://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png' }}" alt="Fork me on GitHub"  class="github"/>
     </a>
     {% endif %}
 

--- a/alabaster/theme.conf
+++ b/alabaster/theme.conf
@@ -12,6 +12,7 @@ github_user =
 github_repo = 
 github_button = true
 github_banner = false
+github_banner_image =
 github_type = watch
 github_count = true
 travis_button = false


### PR DESCRIPTION
The 'github_banner_image' option allows the user to specify an image to
be used as a replacement for the default 'Fork me on Github' banner. The
image path must be relative to `$PROJECT/_static/`. If this option is
unset (which is the default), then the standard 'Fork me on Github'
banner is used.