### PR TITLE
Make GitHub button work in HTTPS

### DIFF
--- a/alabaster/about.html
+++ b/alabaster/about.html
@@ -17,7 +17,7 @@
 
 {% if theme_github_button|lower == 'true' %}
 <p>
-<iframe src="http://ghbtns.com/github-btn.html?user={{ theme_github_user }}&repo={{ theme_github_repo }}&type={{ theme_github_type }}&count={{ theme_github_count }}&size=large"
+<iframe src="https://mdo.github.io/github-buttons/github-btn.html?user={{ theme_github_user }}&repo={{ theme_github_repo }}&type={{ theme_github_type }}&count={{ theme_github_count }}&size=large"
   allowtransparency="true" frameborder="0" scrolling="0" width="200px" height="35px"></iframe>
 </p>
 {% endif %}


### PR DESCRIPTION
My browser refuses to load the GitHub button because my documentation is served via HTTPS but the buttons are available under HTTP.

I'm using the workaround described here: https://github.com/mdo/github-buttons/issues/73