### PR TITLE
Allow code font size and font family to be configured

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,13 @@ To use:
    * `narrow_sidebar_fg`: Text color of same.
    * `narrow_sidebar_link`: Link color of same. Defaults to `gray_3`.
 
+   **Fonts**
+
+   * `code_font_size`: Font size of code block text. Defaults to `0.9em`.
+   * `code_font_family`: Font family of code block test. Defaults to
+   `'Consolas', 'Menlo', 'Deja Vu Sans Mono', 'Bitstream Vera Sans Mono', monospace`
+    
+
 ## Additional info / background
 
 * [Fabric #419](https://github.com/fabric/fabric/issues/419) contains a lot of

--- a/alabaster/static/alabaster.css_t
+++ b/alabaster/static/alabaster.css_t
@@ -280,7 +280,7 @@ p.admonition-title:after {
 }
 
 pre, tt {
-    font-family: 'Consolas', 'Menlo', 'Deja Vu Sans Mono', 'Bitstream Vera Sans Mono', monospace;
+    font-family: {{theme_code_font_family}};
     font-size: {{ theme_code_font_size }};
 }
 

--- a/alabaster/static/alabaster.css_t
+++ b/alabaster/static/alabaster.css_t
@@ -281,7 +281,7 @@ p.admonition-title:after {
 
 pre, tt {
     font-family: 'Consolas', 'Menlo', 'Deja Vu Sans Mono', 'Bitstream Vera Sans Mono', monospace;
-    font-size: 0.9em;
+    font-size: {{ theme_code_font_size }};
 }
 
 img.screenshot {

--- a/alabaster/theme.conf
+++ b/alabaster/theme.conf
@@ -54,3 +54,4 @@ pre_bg =
 narrow_sidebar_bg = #333
 narrow_sidebar_fg = #FFF
 narrow_sidebar_link =
+code_font_size = 0.9em

--- a/alabaster/theme.conf
+++ b/alabaster/theme.conf
@@ -55,3 +55,4 @@ narrow_sidebar_bg = #333
 narrow_sidebar_fg = #FFF
 narrow_sidebar_link =
 code_font_size = 0.9em
+code_font_family = 'Consolas', 'Menlo', 'Deja Vu Sans Mono', 'Bitstream Vera Sans Mono', monospace


### PR DESCRIPTION
Does not change any default styles. Just makes the font size and font family for code blocks configurable.