### PR TITLE
Allow "Page source" link to be hidden

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ To use:
    * `show_powered_by`: Boolean controlling display of the `Powered by Sphinx
    N.N.N. & Alabaster M.M.M` section of the footer. When True, is displayed
    next to the copyright information; when False, is hidden.
+   * `show_source`: Boolean controlling display of the `Page source` link of the footer; when False, is hidden.
 
    **Style colors**
 

--- a/alabaster/layout.html
+++ b/alabaster/layout.html
@@ -15,7 +15,7 @@
       Powered by <a href="http://sphinx-doc.org/">Sphinx {{ sphinx_version }}</a>
       &amp; <a href="https://github.com/bitprophet/alabaster">Alabaster {{ alabaster_version }}</a>
       {% endif %}
-      {%- if show_source and has_source and sourcename %}
+      {%- if theme_show_source and show_source and has_source and sourcename %}
       |
       <a href="{{ pathto('_sources/' + sourcename, true)|e }}"
           rel="nofollow">{{ _('Page source') }}</a></li>

--- a/alabaster/theme.conf
+++ b/alabaster/theme.conf
@@ -22,6 +22,7 @@ touch_icon =
 extra_nav_links =
 sidebar_includehidden = true
 show_powered_by = true
+show_source = true
 
 gray_1 = #444
 gray_2 = #EEE


### PR DESCRIPTION
Docs hosted on ReadTheDocs already give you  the option to view and edit a page's source on GitHub. 

![quickstart_ _marshmallow_1_1_0_documentation](https://cloud.githubusercontent.com/assets/2379650/5329112/84179efa-7d6c-11e4-87a7-e1cf664ea649.png)

This makes the "Page source" link redundant. This patch allows a user to hide the link.