### PR TITLE
Allow tagline font-style to be configured

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ To use:
    * `logo_text_align`: Which CSS `text-align` value to use for logo text (if
    there is any.)
    * `description`: Text blurb about your project, to appear under the logo.
+   * `description_font_style`: Which CSS `font-style` to use for description text. Defaults to `normal`.
    * `github_user`, `github_repo`: Used by `github_button` and `github_banner`
    (see below); does nothing if both of those are set to `false`.
    * `github_button`: `true` or `false` (default: `true`) - whether to link to

--- a/alabaster/static/alabaster.css_t
+++ b/alabaster/static/alabaster.css_t
@@ -111,6 +111,7 @@ div.sphinxsidebarwrapper h1.logo-name {
 
 div.sphinxsidebarwrapper p.blurb {
     margin-top: 0;
+    font-style: {{ theme_description_font_style }};
 }
 
 div.sphinxsidebar h3,

--- a/alabaster/theme.conf
+++ b/alabaster/theme.conf
@@ -8,6 +8,7 @@ logo =
 logo_name = false
 logo_text_align = left
 description =
+description_font_style = normal
 github_user = 
 github_repo = 
 github_button = true


### PR DESCRIPTION
Personally, I like the tagline to be in italic font. This patch doesn't change the default styling, but allows the font-style to be configured.