### PR TITLE
Declare extension version and parallel read safety

### DIFF
--- a/alabaster/__init__.py
+++ b/alabaster/__init__.py
@@ -16,3 +16,5 @@ def update_context(app, pagename, templatename, context, doctree):
 
 def setup(app):
     app.connect('html-page-context', update_context)
+    return {'version': version.__version__,
+            'parallel_read_safe': True}


### PR DESCRIPTION
This is necessary for Sphinx' parallel read feature to work, since we import alabaster all the time now.