### PR TITLE
Fix styling of emphasized/highlighted lines

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -229,6 +229,7 @@ colorscheme. The more granular settings can be used to override as needed.
   it to the bottom of the page.
 * ``narrow_sidebar_fg``: Text color of same.
 * ``narrow_sidebar_link``: Link color of same. Defaults to ``gray_3``.
+* ``code_highlight``: Color of highlight when using ``:emphasize-lines:`` in a code block.
 
 Fonts
 -----

--- a/alabaster/static/alabaster.css_t
+++ b/alabaster/static/alabaster.css_t
@@ -287,6 +287,13 @@ pre, tt, code {
     font-size: {{ theme_code_font_size }};
 }
 
+.hll {
+    background-color: {{theme_code_highlight}};
+    margin: 0 -12px;
+    padding: 0 12px;
+    display: block;
+}
+
 img.screenshot {
 }
 

--- a/alabaster/theme.conf
+++ b/alabaster/theme.conf
@@ -61,3 +61,4 @@ code_font_size = 0.9em
 code_font_family = 'Consolas', 'Menlo', 'Deja Vu Sans Mono', 'Bitstream Vera Sans Mono', monospace
 font_family = 'goudy old style', 'minion pro', 'bell mt', Georgia, 'Hiragino Mincho Pro', serif
 head_font_family = 'Garamond', 'Georgia', serif
+code_highlight = #FFC


### PR DESCRIPTION
Fixes the highlight styling when using the `:emphasize-lines:` option in a code block. Also makes the highlight color configurable.

### Before

![quickstart_ _marshmallow_2_0_0-dev_documentation](https://cloud.githubusercontent.com/assets/2379650/7221033/708b9894-e6aa-11e4-956a-092d5e91dcb9.png)

### After

![quickstart_ _marshmallow_2_0_0-dev_documentation](https://cloud.githubusercontent.com/assets/2379650/7221034/8771bbe2-e6aa-11e4-9c30-fa0128c00a2b.png)

