### PR TITLE
Use https URL for the "forkme" image on AWS

### DIFF
--- a/alabaster/layout.html
+++ b/alabaster/layout.html
@@ -29,7 +29,7 @@
 
     {% if theme_github_banner|lower != 'false' %}
     <a href="https://github.com/{{ theme_github_user }}/{{ theme_github_repo }}" class="github">
-        <img style="position: absolute; top: 0; right: 0; border: 0;" src="{{ pathto('_static/' ~ theme_github_banner, 1) if theme_github_banner|lower != 'true' else 'http://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png' }}" alt="Fork me on GitHub"  class="github"/>
+        <img style="position: absolute; top: 0; right: 0; border: 0;" src="{{ pathto('_static/' ~ theme_github_banner, 1) if theme_github_banner|lower != 'true' else 'https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png' }}" alt="Fork me on GitHub"  class="github"/>
     </a>
     {% endif %}
 


### PR DESCRIPTION
To fix an insecure resource warning when using the alabaster theme on an HTTPS site.