### PR TITLE
Configure wheels to be universal

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+universal = 1


### PR DESCRIPTION
Adds a config option so that wheels generated with:

    python setup.py bdist_wheel

will be universal (python 2 / 3).

See #33