### PR TITLE
Removed Gap between Footnote Label and Description

### DIFF
--- a/alabaster/static/alabaster.css_t
+++ b/alabaster/static/alabaster.css_t
@@ -355,7 +355,7 @@ table.field-list p {
 }
 
 table.footnote td.label {
-    width: 0px;
+    width: .1px;
     padding: 0.3em 0 0.3em 0.5em;
 }
 


### PR DESCRIPTION
The default label width of 0px is ignored by the browsers: http://prntscr.com/997jre

Set the width to any non-zero value, and the footnotes looks fine: http://prntscr.com/997k3w