### PR TITLE
Allow control of body text alignment

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -135,6 +135,8 @@ Variables and feature toggles
   project name itself. Defaults to ``false``.
 * ``logo_text_align``: Which CSS ``text-align`` value to use for logo text
   (if there is any.)
+* ``body_text_align``: Which CSS ``text-align`` value to use for body text
+  (if there is any.)
 * ``description``: Text blurb about your project, to appear under the logo.
 * ``description_font_style``: Which CSS ``font-style`` to use for description
   text. Defaults to ``normal``.

--- a/alabaster/static/alabaster.css_t
+++ b/alabaster/static/alabaster.css_t
@@ -56,6 +56,10 @@ div.body {
     padding: 0 30px 0 30px;
 }
 
+div.body > .section {
+    text-align: {{ theme_body_text_align }};
+}
+
 div.footer {
     width: {{ theme_page_width }};
     margin: 20px auto 30px auto;

--- a/alabaster/theme.conf
+++ b/alabaster/theme.conf
@@ -33,6 +33,7 @@ pink_1 = #FCC
 pink_2 = #FAA
 
 body_text = #3E4349
+body_text_align = left
 footer_text = #888
 link = #004B6B
 link_hover = #6D4100


### PR DESCRIPTION
I have been looking for an easy way to configure the text alignment in the body text when exporting to HTML. I haven't found any, so I changed a couple of lines in the code. Pulling just in case it's useful to someone.