### PR TITLE
Fix a few html mismatched + closing tags

### DIFF
--- a/alabaster/about.html
+++ b/alabaster/about.html
@@ -3,7 +3,7 @@
   <a href="{{ pathto(master_doc) }}">
     <img class="logo" src="{{ pathto('_static/' ~ theme_logo, 1) }}" alt="Logo"/>
     {% if theme_logo_name|lower == 'true' %}
-    <h1 class="logo logo-name">{{ project }}</h2>
+    <h1 class="logo logo-name">{{ project }}</h1>
     {% endif %}
   </a>
 </p>
@@ -33,7 +33,7 @@
     <img
         alt="https://secure.travis-ci.org/{{ path }}.png?branch=master"
         src="https://secure.travis-ci.org/{{ path }}.png?branch=master"
-    >
+    />
 </a>
 </p>
 {% endif %}

--- a/alabaster/layout.html
+++ b/alabaster/layout.html
@@ -5,7 +5,7 @@
   {% if theme_touch_icon %}
     <link rel="apple-touch-icon" href="{{ pathto('_static/' ~ theme_touch_icon, 1) }}" />
   {% endif %}
-  <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
+  <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9" />
 {% endblock %}
 
 {# Disable base theme's top+bottom related navs; we have our own in sidebar #}


### PR DESCRIPTION
These things mainly tend to manifest themselves when the content type is set to something like:

```
Content-Type: application/xhtml+xml
```