### PR TITLE
HTML-escape the ampersand symbols

### DIFF
--- a/alabaster/about.html
+++ b/alabaster/about.html
@@ -18,7 +18,7 @@
 {% if theme_github_user and theme_github_repo %}
 {% if theme_github_button|lower == 'true' %}
 <p>
-<iframe src="https://ghbtns.com/github-btn.html?user={{ theme_github_user }}&repo={{ theme_github_repo }}&type={{ theme_github_type }}&count={{ theme_github_count }}&size=large"
+<iframe src="https://ghbtns.com/github-btn.html?user={{ theme_github_user }}&amp;repo={{ theme_github_repo }}&amp;type={{ theme_github_type }}&amp;count={{ theme_github_count }}&amp;size=large"
   allowtransparency="true" frameborder="0" scrolling="0" width="200px" height="35px"></iframe>
 </p>
 {% endif %}


### PR DESCRIPTION
As is, this leads to nasty looking warnings like:
```text
EntityRef: expecting ';'
```

When the content-type is set to something like:
```text
application/xhtml+xml
```