### PR TITLE
Don't put an underline on linked images.

### DIFF
--- a/alabaster/static/alabaster.css_t
+++ b/alabaster/static/alabaster.css_t
@@ -419,6 +419,11 @@ a.reference {
     border-bottom: 1px dotted {{ theme_link }};
 }
 
+/* Don't put an underline on images */
+a.image-reference {
+    border-bottom: none;
+}
+
 a.reference:hover {
     border-bottom: 1px solid {{ theme_link_hover }};
 }


### PR DESCRIPTION
I imagine most users don't want images that are clickable
to be underlined.
It makes the UI look a bit ugly,
and isn't really standard practice.