### PR TITLE
Add support for canonical URL headers

### DIFF
--- a/alabaster/layout.html
+++ b/alabaster/layout.html
@@ -6,6 +6,9 @@
   {% if theme_touch_icon %}
     <link rel="apple-touch-icon" href="{{ pathto('_static/' ~ theme_touch_icon, 1) }}" />
   {% endif %}
+  {% if theme_canonical_url %}
+    <link rel="canonical" href="{{ theme_canonical_url }}{{ pagename }}.html"/>
+  {% endif %}
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9" />
 {% endblock %}
 

--- a/alabaster/theme.conf
+++ b/alabaster/theme.conf
@@ -21,6 +21,7 @@ gratipay_user =
 gittip_user =
 analytics_id =
 touch_icon =
+canonical_url =
 extra_nav_links =
 sidebar_includehidden = true
 show_powered_by = true


### PR DESCRIPTION
[Canonical URL headers](https://support.google.com/webmasters/answer/139066?rd=1) allow search engines to more accurately identify the canonical source of a document.