### PR TITLE
Set correct variable name for admonition bg

### DIFF
--- a/alabaster/static/alabaster.css_t
+++ b/alabaster/static/alabaster.css_t
@@ -10,7 +10,7 @@
 
 {# set up admonition styling #}
 {# - basic level #}
-{% set admonition_xref_bg = theme_admonition_xref_bg or theme_xref_bg %}
+{% set theme_admonition_xref_bg = theme_admonition_xref_bg or theme_xref_bg %}
 {% set theme_admonition_bg = theme_admonition_bg or theme_gray_2 %}
 {% set theme_note_bg = theme_note_bg or theme_gray_2 %}
 {% set theme_seealso_bg = theme_seealso_bg or theme_gray_2 %}


### PR DESCRIPTION
The wrong variable name was set for the `admonition_xref_bg` variable (missing `theme_` prefix), resulting in a blank where the variable was used under normal circumstances. This resulted in invalid CSS. I believe this is the intended behavior, to inherit from `xref_bg`.