### PR TITLE
add option "badge_branch"

### DIFF
--- a/alabaster/about.html
+++ b/alabaster/about.html
@@ -33,8 +33,8 @@
 <p>
 <a href="https://travis-ci.org/{{ path }}">
     <img
-        alt="https://secure.travis-ci.org/{{ path }}.svg?branch=master"
-        src="https://secure.travis-ci.org/{{ path }}.svg?branch=master"
+        alt="https://secure.travis-ci.org/{{ path }}.svg?branch={{ theme_badge_branch }}"
+        src="https://secure.travis-ci.org/{{ path }}.svg?branch={{ theme_badge_branch }}"
     />
 </a>
 </p>
@@ -49,8 +49,8 @@
 <p>
 <a href="https://codecov.io/github/{{ path }}">
     <img
-    alt="https://codecov.io/github/{{ path }}/coverage.svg?branch=master"
-    src="https://codecov.io/github/{{ path }}/coverage.svg?branch=master"
+    alt="https://codecov.io/github/{{ path }}/coverage.svg?branch={{ theme_badge_branch }}"
+    src="https://codecov.io/github/{{ path }}/coverage.svg?branch={{ theme_badge_branch }}"
     />
 </a>
 </p>

--- a/alabaster/theme.conf
+++ b/alabaster/theme.conf
@@ -15,6 +15,7 @@ github_button = true
 github_banner = false
 github_type = watch
 github_count = true
+badge_branch = master
 travis_button = false
 codecov_button = false
 gratipay_user =

--- a/docs/customization.rst
+++ b/docs/customization.rst
@@ -104,6 +104,9 @@ Variables and feature toggles
      ``$PROJECT/_static/``) to be used as the banner image instead of the
      default.
 
+* ``badge_branch``: Set which branch to be used to show badges.
+  Defaults to ``master``.
+
 * ``travis_button``: ``true``, ``false`` or a Github-style ``"account/repo"``
   string - used to display a `Travis-CI <https://travis-ci.org>`_ build status
   button in the sidebar. If ``true``, uses your ``github_(user|repo)``


### PR DESCRIPTION
some project does not treat "master" as main branch to
be shown in badge. They may have a "release" branch and
want it to be shown in badge. add a option "badge_branch"
to make it possible to control which branch to be shown.