### PR TITLE
Sidebar little improvement

### DIFF
--- a/alabaster/static/alabaster.css_t
+++ b/alabaster/static/alabaster.css_t
@@ -121,6 +121,11 @@ div.relations {
 }
 {% endif %}
 
+div.sphinxsidebar {
+    max-height: 100%;
+    overflow-y: auto;
+}
+
 div.sphinxsidebar a {
     color: {{ theme_sidebar_link }};
     text-decoration: none;
@@ -205,6 +210,10 @@ div.sphinxsidebar input {
     border: 1px solid {{ theme_sidebar_search_button }};
     font-family: {{ theme_font_family }};
     font-size: 1em;
+}
+
+div.sphinxsidebar #searchbox input[type="text"] {
+    width: 160px;
 }
 
 div.sphinxsidebar .search > div {

--- a/alabaster/static/alabaster.css_t
+++ b/alabaster/static/alabaster.css_t
@@ -207,6 +207,10 @@ div.sphinxsidebar input {
     font-size: 1em;
 }
 
+div.sphinxsidebar .search > div {
+    display: table-cell;
+}
+
 div.sphinxsidebar hr {
     border: none;
     height: 1px;


### PR DESCRIPTION
**ensure search input bar and button in one line**
The quick search bar and button in sidebar is splited in two lines which looks not so nice. Make them in one line.

*Before:*
![button_before](https://user-images.githubusercontent.com/19969470/30768063-6043f6e2-a035-11e7-9412-b2492bb6e28f.png)

*After:*
![2017-09-23 08-05-57](https://user-images.githubusercontent.com/19969470/30768123-13bece54-a036-11e7-8869-af89b42103c3.png)


**add scrollbar for fixed sidebar if it's height is bigger than page height**
For fixed sidebar, the content out of page will not able to show. Add a scrollbar for this situation so that users can scroll down and see that content.

*Before:*
![2017-09-23 08-08-04](https://user-images.githubusercontent.com/19969470/30768152-603cd5be-a036-11e7-981a-8d569db2887b.png)

*After:*
![2017-09-23 08-07-34](https://user-images.githubusercontent.com/19969470/30768155-694d8b4e-a036-11e7-9a58-d92188caf819.png)
