### PR TITLE
Only load Google Analytics if user have not opt-in to DoNotTrack.

### DIFF
--- a/alabaster/layout.html
+++ b/alabaster/layout.html
@@ -64,18 +64,23 @@
 
     {% if theme_analytics_id %}
     <script type="text/javascript">
+      // Only load GA if DNT is not set
+      if (navigator.doNotTrack != "1" && // Most Firefox & Chrome
+             window.doNotTrack != "1" && // IE & Safari
+        navigator.msDoNotTrack != "1"    // Old IE
+        ) {
+          var _gaq = _gaq || [];
+          _gaq.push(['_setAccount', '{{ theme_analytics_id }}']);
+          _gaq.push(['_setDomainName', 'none']);
+          _gaq.push(['_setAllowLinker', true]);
+          _gaq.push(['_trackPageview']);
 
-      var _gaq = _gaq || [];
-      _gaq.push(['_setAccount', '{{ theme_analytics_id }}']);
-      _gaq.push(['_setDomainName', 'none']);
-      _gaq.push(['_setAllowLinker', true]);
-      _gaq.push(['_trackPageview']);
-
-      (function() {
-        var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
-        ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
-        var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
-      })();
+          (function() {
+            var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
+            ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
+            var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
+          })();
+      }
 
     </script>
     {% endif %}


### PR DESCRIPTION
GA does not respect the "DoNotTrack" setting, so conditionally load it
only if it is not set by user.

Alternatively it appears that GA.js is deprected and has been replace by
analytics.js (according to official google Documentation [0]:

> ga.js is a legacy library. If you are starting a new implementation,
> we recommend you use the latest version of this library,
> analytics.js[1]. For existing implementations, learn how to migrate from
> ga.js to analytics.js[2].

But that will be the subject of another pull-request if maintainers
agrees that updating the theme from GA to analytics is desired.

0: https://developers.google.com/analytics/devguides/collection/gajs/
1: https://developers.google.com/analytics/devguides/collection/analyticsjs/
2: https://developers.google.com/analytics/devguides/collection/upgrade/

[Edit]

You can view the file diff with [`?w=1`](https://github.com/bitprophet/alabaster/pull/123/files?w=1) to ignore the change in indentation of the code snippet, making the review easier. 