### PR TITLE
Changed logo_name option to take an arbitrary string.

### DIFF
--- a/alabaster/about.html
+++ b/alabaster/about.html
@@ -2,8 +2,8 @@
 <p class="logo">
   <a href="{{ pathto(master_doc) }}">
     <img class="logo" src="{{ pathto('_static/' ~ theme_logo, 1) }}" alt="Logo"/>
-    {% if theme_logo_name|lower == 'true' %}
-    <h1 class="logo logo-name">{{ project }}</h1>
+    {% if theme_logo_name %}
+    <h1 class="logo logo-name">{{ theme_logo_name }}</h1>
     {% endif %}
   </a>
 </p>


### PR DESCRIPTION
This addresses #55 by removing the hard-coding of the value of `project` when using the `logo_name` theme option.  Instead, `logo_name` is interpreted as a string, which is displayed directly.

Other options can be referred directly using the appropriate variable in `conf.py`; e.g.:

```
html_theme_options = {
    'logo_name': html_title_short,
}
```