### PR TITLE
Bump version dev requirements to Sphinx 1.8 and below

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,4 @@
-sphinx>=1.3,<1.7
+sphinx>=1.3,<1.8
 invoke>=1.0.0
 invocations>=1.2.0
 semantic_version>=2.4,<2.5


### PR DESCRIPTION
(Originally I thought this was a larger issue.)

Here's an example of alabaster with Sphinx 1.7.5: https://tmuxp.git-pull.com/en/latest/