### PR TITLE
Add tidelift_url customization option

### DIFF
--- a/alabaster/donate.html
+++ b/alabaster/donate.html
@@ -7,3 +7,11 @@ Consider supporting the authors on <a href="https://www.gratipay.com/">Gratipay<
         src="//gttp.co/v1.js"></script>
 </p>
 {% endif %}
+
+{% if theme_tidelift_url %}
+<h3>Professional support</h3>
+<p>
+Professionally-supported {{ project }} is available with the
+<a href="{{ theme_tidelift_url }}">Tidelift Subscription</a>.
+</p>
+{% endif %}

--- a/alabaster/theme.conf
+++ b/alabaster/theme.conf
@@ -20,6 +20,7 @@ travis_button = false
 codecov_button = false
 gratipay_user =
 gittip_user =
+tidelift_url =
 analytics_id =
 touch_icon =
 canonical_url =

--- a/docs/customization.rst
+++ b/docs/customization.rst
@@ -107,6 +107,8 @@ Variables and feature toggles
   string - used to display a `Travis-CI <https://travis-ci.org>`_ build status
   button in the sidebar. If ``true``, uses your ``github_(user|repo)``
   settings.
+* ``tidelift_url``: Set your `Tidelift <https://tidelift.com/>`_ project
+  URL if you want a "Professional support" section in your sidebar.
 * ``codecov_button``: ``true``, ``false`` or a Github-style ``"account/repo"``
   string - used to display a `Codecov <https://codecov.io>`_ build status
   button in the sidebar. If ``true``, uses your ``github_(user|repo)``


### PR DESCRIPTION
Allows adding a Tidelift section to the sidebar 
by setting the `tidelift_url` theme option.

**Screenshot**

![screenshot](https://user-images.githubusercontent.com/2379650/45132398-cf6efe00-b15e-11e8-887b-6bf8e41e2f87.png)