### PR TITLE
Add testing and document support for Python 3.7 and 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
+  - "3.7"
+  - "3.8"
   - "pypy"
   - "pypy3"
 env:
@@ -14,12 +16,6 @@ env:
   - SPHINX=">=1.6,<1.7"
   - SPHINX=">=1.7,<1.8"
 install:
-  # For some reason Travis' build envs have wildly different pip/setuptools
-  # versions between minor Python versions, and this can cause many hilarious
-  # corner packaging cases. So...
-  - pip install -U pip
-  # Setuptools 34+ seems to get less stable
-  - pip install 'setuptools>33,<34'
   # Install dev requirements
   - pip install -r dev-requirements.txt
   # Limit Sphinx version re: test matrix

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -5,7 +5,7 @@ semantic_version>=2.4,<2.5
 wheel==0.24
 twine==1.11.0
 releases>=1.5.1,<2.0
-flake8==3.6.0
+flake8
 
 # Install ourselves direct, even when being used on eg RTD. Otherwise we can't
 # dogfood our own changes until release to PyPI.

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,8 @@ setup(
         "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",
         "Topic :: Documentation",


### PR DESCRIPTION
Python 3.7 was released on June 27, 2018.

Python 3.8 was released on October 14th, 2019.