### PR TITLE
Adjust page width in mobile to device width

### DIFF
--- a/alabaster/static/alabaster.css_t
+++ b/alabaster/static/alabaster.css_t
@@ -625,13 +625,13 @@ a:hover tt, a:hover code {
     div.sphinxsidebar {
         display: block;
         float: none;
-        width: 102.5%;
+        width: 100%;
         {%- if theme_fixed_sidebar|lower == 'true' %}
         margin: -20px -30px 20px -30px;
         {%- else %}
         margin: 50px -30px -20px -30px;
         {%- endif %}
-        padding: 10px 20px;
+        padding: 10px 30px;
         background: {{ theme_narrow_sidebar_bg }};
         color: {{ theme_narrow_sidebar_fg }};
     }
@@ -663,6 +663,9 @@ a:hover tt, a:hover code {
     }
 
     div.body {
+        /* reset basic.css */
+        min-width: unset;
+
         min-height: 0;
         padding: 0;
     }


### PR DESCRIPTION
solve https://github.com/bitprophet/alabaster/issues/139 and improve https://github.com/bitprophet/alabaster/pull/140

I noticed the bug and investigated implementation of Sphinx. Related feature was added in Sphinx v1.7.0 and implemented on https://github.com/sphinx-doc/sphinx/pull/4376 .

I think it's better to describe `mix-width` property in media queries and the value as `unset` as this PR.

# Reasons

* min-width and max-width of div.body are defined as theme options of basic theme. Because Alabaster inherit basic theme, end user can change the value like bellow. If static value is defined in alabaster.css, these options will be meaningless.

    ```python
    # conf.py example
    html_theme_options = {
      'body_min_width': 320,
      'body_max_width': 640,
    }
    ```

* I think this sphinx feature (and basic theme) is assumed to be browsed on only PC browser and there is no need to have fixed value to these property on smartphone.

# About other changes

When I tested this changes, I noticed that the sidebar width is not fit to widow size.

* I think padding value of sidebar should be 30px (same of outer margin). Unfortunately, I couldn't understand why the width is 102.5%, but It looks good also to be 100% at my testing.
