### PR TITLE
Remove testing for end-of-life Python 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: python
 cache: pip
 python:
   - "2.7"
-  - "3.4"
   - "3.5"
   - "3.6"
   - "pypy"

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,6 @@ setup(
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.2",
         "Programming Language :: Python :: 3.3",
-        "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: Implementation :: CPython",


### PR DESCRIPTION
Python 3.4 has been EOL since 2019-03-18.

Removing from the test matrix helps reduce testing resources.