### PR TITLE
Remove redundant type="text/javascript" from <script> elements

### DIFF
--- a/alabaster/layout.html
+++ b/alabaster/layout.html
@@ -106,7 +106,7 @@
     {% endif %}
 
     {% if theme_analytics_id %}
-    <script type="text/javascript">
+    <script>
 
       var _gaq = _gaq || [];
       _gaq.push(['_setAccount', '{{ theme_analytics_id }}']);
@@ -115,7 +115,7 @@
       _gaq.push(['_trackPageview']);
 
       (function() {
-        var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
+        var ga = document.createElement('script'); ga.async = true;
         ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
         var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
       })();


### PR DESCRIPTION
In HTML5, <script> elements default to MIME type text/javascript. The
HTML5 living standard and MDN recommend against including the attribute.

From https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script#attr-type

> The HTML5 specification urges authors to omit the attribute rather
> than provide a redundant MIME type.

From https://html.spec.whatwg.org/#the-script-element

> Authors should omit the type attribute instead of redundantly setting
> it.