### PR TITLE
Fix horizontal scrolling on mobile

### DIFF
--- a/alabaster/theme.conf
+++ b/alabaster/theme.conf
@@ -4,6 +4,7 @@ stylesheet = alabaster.css
 pygments_style = alabaster.support.Alabaster
 
 [options]
+body_min_width = inherit
 analytics_id =
 badge_branch = master
 canonical_url =


### PR DESCRIPTION
Alabaster inherits from the "basic" theme which sets body_min_width to
450, resulting in body_min_width: 450px, which doesn't make any sense
for Alabaster since it's actually responsive.

Fixes #139.