### PR TITLE
Remove underline from whitespace

### DIFF
--- a/alabaster/support.py
+++ b/alabaster/support.py
@@ -25,7 +25,7 @@ class Alabaster(Style):
     styles = {
         # No corresponding class for the following:
         # Text:                     "", # class:  ''
-        Whitespace: "underline #f8f8f8",  # class: 'w'
+        Whitespace: "#f8f8f8",  # class: 'w'
         Error: "#a40000 border:#ef2929",  # class: 'err'
         Other: "#000000",  # class 'x'
         Comment: "italic #8f5902",  # class: 'c'


### PR DESCRIPTION
The latest version of pygments seems to have started applying the `w` class to whitespace, which looks bad for code samples:

![image](https://user-images.githubusercontent.com/10931297/150431094-86be5243-bd50-4a06-a443-a9dcee5707f6.png)

Especially in dark theme or when selected:

![image](https://user-images.githubusercontent.com/10931297/150431141-eebc08db-c996-42ea-95b7-2a56eda240ae.png)

They can't see why the `w` class has a text underline [and removed it](https://github.com/pygments/pygments/issues/2020), but Alabaster has it explicitly set so need to remove it here too.
