### PR TITLE
Add support for multiple copyright statements

### DIFF
--- a/alabaster/layout.html
+++ b/alabaster/layout.html
@@ -85,9 +85,31 @@
 {%- endif %}
 {%- endblock %}
 
+{%- macro pipe_split_copyright_block() %}
+  {%- if hasdoc('copyright') %}
+    {%- set copyright_prefix = '<a href="' + pathto('copyright') + '">' + _('Copyright') + '</a>' -%}
+  {%- else %}
+    {%- set copyright_prefix = _('Copyright') %}
+  {%- endif %}
+  {%- if copyright is iterable and copyright is not string %}
+    {% for copyright_line in copyright %}
+      {% trans trimmed copyright_prefix=copyright_prefix, copyright=copyright_line|e %}
+        &#169; {{ copyright_prefix }} {{ copyright }}.
+      {% endtrans %}
+      {% if not loop.last %}|{% endif %}
+    {% endfor %}
+  {%- else %}
+    {% trans trimmed copyright_prefix=copyright_prefix, copyright=copyright|e %}
+      &#169; {{ copyright_prefix }} {{ copyright }}.
+    {% endtrans %}
+  {%- endif %}
+{%- endmacro %}
+
 {%- block footer %}
     <div class="footer">
-      {% if show_copyright %}&#169;{{ copyright }}.{% endif %}
+      {%- if show_copyright %}
+        {{- pipe_split_copyright_block() -}}
+      {%- endif %}
       {% if show_sphinx %}
       {% if show_copyright %}|{% endif %}
       Powered by <a href="https://www.sphinx-doc.org/">Sphinx {{ sphinx_version }}</a>


### PR DESCRIPTION
I have implemented a fix for the relevant issue #224 I created that separates multiple copyright statements with pipes | instead of displaying the raw list of copyright notices.